### PR TITLE
Add OLCF Training links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You know a great resource we should add? Please see [How to contribute](#how-to-
 - [CUDA Toolkit Documentation ](https://docs.nvidia.com/cuda/)
 - Basic terminology: Thread block, Warp, Streaming Multiprocessor: [Wiki: Thread Block](https://en.wikipedia.org/wiki/Thread_block_(CUDA_programming)), [A tour of CUDA](https://tbetcke.github.io/hpc_lecture_notes/cuda_introduction.html)
 - [GPU Performance Background User's Guide](https://docs.nvidia.com/deeplearning/performance/dl-performance-gpu-background/index.html)
+- [OLCF NVIDIA CUDA Training Series](https://www.olcf.ornl.gov/cuda-training-series/), talk recordings can be found under the presentation footer for each lecture; [exercises](https://github.com/olcf/cuda-training-series)
 
 
 ## Papers, Case Studies


### PR DESCRIPTION
Adds link to a course to the OLCF by NVIDIA on cuda basics, terminology and optimizations which includes exercises as well. 