### PR TITLE
Add GTC 2021 talk on GPU Computing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You know a great resource we should add? Please see [How to contribute](#how-to-
 - [pybind11 documentation](https://pybind11.readthedocs.io/en/stable/)
 - [NVIDIA Tensor Core Programming](https://leimao.github.io/blog/NVIDIA-Tensor-Core-Programming/)
 - [GPU Programming: When, Why and How?](https://enccs.github.io/gpu-programming/#)
+- [How GPU Computing Works | GTC 2021](https://youtu.be/3l10o0DYJXg?si=t5FHswnibAbo3s0t)
 - [How CUDA Programming Works | GTC 2022](https://youtu.be/n6M8R8-PlnE?si=cJ4dWtpYaPoIuJ0q)
 
 


### PR DESCRIPTION
Adds a link to Stephen Jones' talk from GTC 2021 on "How GPU Computing Works". Is a bit more basic compared to his GTC 2022 talk on CUDA programming and should be a good addition for "Essentials"