### PR TITLE
Add "An Even easier introduction to CUDA" to the resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You know a great resource we should add? Please see [How to contribute](#how-to-
 
 ## 1st Contact with CUDA
 - [An Easy Introduction to CUDA C and C++](https://developer.nvidia.com/blog/easy-introduction-cuda-c-and-c/)
+- [An Even Easier Introduction to CUDA](https://developer.nvidia.com/blog/even-easier-introduction-cuda/)
 - [CUDA Toolkit Documentation ](https://docs.nvidia.com/cuda/)
 - Basic terminology: Thread block, Warp, Streaming Multiprocessor: [Wiki: Thread Block](https://en.wikipedia.org/wiki/Thread_block_(CUDA_programming)), [A tour of CUDA](https://tbetcke.github.io/hpc_lecture_notes/cuda_introduction.html)
 - [GPU Performance Background User's Guide](https://docs.nvidia.com/deeplearning/performance/dl-performance-gpu-background/index.html)


### PR DESCRIPTION
NVIDIA provides an updated tutorial for hands-on CUDA. It's simpler than the 2013 post.